### PR TITLE
Pocknix fancontrol hysteresis and changed quiet curve

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Force LF line endings on shell scripts so they stay runnable after being
+# checked out on Windows and copied (scp/git) onto the device. A CRLF shebang
+# (/bin/sh\r) makes systemd fail with status 203/EXEC ("No such file or
+# directory"). Scripts land in /usr/local/bin (overlay) and /usr/bin
+# (packages/pocknix-bsp-common) and are invoked directly by systemd units, so
+# both locations need protecting regardless of filename extension.
+*.sh        text eol=lf
+overlay/**  text eol=lf
+packages/pocknix-bsp-common/* text eol=lf

--- a/packages/pocknix-bsp-common/PKGBUILD
+++ b/packages/pocknix-bsp-common/PKGBUILD
@@ -5,7 +5,7 @@
 # devices/<name>/packages/pocknix-bsp-<name>, which depends on this package.
 pkgname=pocknix-bsp-common
 pkgver=0.1.0
-pkgrel=5
+pkgrel=6
 pkgdesc="pocknix shared board support: sleep.d dispatcher, suspend hooks, power-key policy, session udev rules, wheel sudo, fan/scheduler daemons"
 arch=('any')
 url="https://github.com/shuuri-labs/pocknix-os"

--- a/packages/pocknix-bsp-common/pocknix-fancontrol
+++ b/packages/pocknix-bsp-common/pocknix-fancontrol
@@ -3,13 +3,18 @@
 # Ported from ROCKNIX hardware/quirks/platforms/SM8550/bin/fancontrol (+ 005-thermal_path /
 # 020-fan_control). Without this nothing takes PWM control of the fan, so it never spins and the
 # device cooks. Discovers the hwmon PWM fan + the CPU/GPU thermal zones, then drives pwm1 from a
-# temp->speed table every few seconds. Runs as root (writes /sys).
+# temp->speed table every few seconds (with hysteresis near thresholds so the fan doesn't
+# oscillate when temp hovers on a boundary). Runs as root (writes /sys).
 #
 # Curve selection: /var/lib/pocknix/fan-mode (quiet|moderate|performance), re-read every tick so
 # the Pocknix Control plugin / pocknix-fan-mode switch curves live with a bare file write — no
 # service restart. Curves = ROCKNIX's of the same names ("performance" = their "aggressive").
 # Default quiet — ROCKNIX's SHIPPED default (rocknix system.cfg: cooling.profile=quiet). We
 # previously baked "moderate" (fan from 55°C, every step 5-10°C earlier) — obnoxiously loud.
+# quiet is now a custom early-quiet curve measured on an SM8550 blower (PWM→RPM sweep on
+# hwmon40): the motor starts at PWM=20 (~950 RPM) and stays barely audible through PWM=50
+# (~1935 RPM), so it ramps in from 50°C at that floor instead of the old 0→51 jump at 60°C.
+# Gentle steps (50/70/80/90/102/153/255) keep the whistle band (PWM 80+, ~2900 RPM) above 70°C.
 set -u
 
 MODE_FILE=/var/lib/pocknix/fan-mode
@@ -30,9 +35,12 @@ for z in /sys/devices/virtual/thermal/thermal_zone*/; do
 done
 [ -n "${SENSORS}" ] || { echo "pocknix-fancontrol: no cpu/gpu thermal zones, exiting"; exit 0; }
 
-# PWM (0-255) vs temperature (millidegC) tables, highest first. Same speed steps for every
-# mode (ROCKNIX's); only the temperature thresholds shift.
-SPEEDS="255 204 153 119 102 77 51 0"
+# Curve = "temp:pwm" pairs, hottest threshold first (threshold in millidegC, pwm 0-255). The
+# loop walks the list and applies the pwm of the first threshold the current temp exceeds.
+# moderate/performance keep ROCKNIX's steps; quiet is the custom early-quiet curve above.
+CURVE_QUIET="88000:255 82000:153 78000:102 74000:90 70000:80 65000:70 50000:50 0:0"
+CURVE_MODERATE="85000:255 80000:204 75000:153 70000:119 65000:102 60000:77 55000:51 0:0"
+CURVE_PERFORMANCE="80000:255 75000:204 70000:153 65000:119 60000:102 55000:77 50000:51 0:0"
 
 # Per-game override: "<pid> <fan> <lavd>" written by pocknix-proton-wrapper. The pid IS the
 # game session (the wrapper execs into Proton), so a dead pid means no override — the pick
@@ -47,11 +55,11 @@ effective_mode() {
   cat "${MODE_FILE}" 2>/dev/null
 }
 
-curve_temps() {
+curve_pairs() {
   case "$(effective_mode)" in
-    performance) echo "80000 75000 70000 65000 60000 55000 50000 0" ;;  # ROCKNIX "aggressive"
-    moderate)    echo "85000 80000 75000 70000 65000 60000 55000 0" ;;
-    *)           echo "95000 85000 80000 75000 70000 65000 60000 0" ;;  # quiet (default)
+    performance) echo "${CURVE_PERFORMANCE}" ;;
+    moderate)    echo "${CURVE_MODERATE}" ;;
+    *)           echo "${CURVE_QUIET}" ;;
   esac
 }
 
@@ -61,12 +69,12 @@ trap '[ -e "${FAN_EN}" ] && echo 0 > "${FAN_EN}" 2>/dev/null; exit 0' INT TERM
 
 LAST=""
 while :; do
-  TEMPS="$(curve_temps)"
+  PAIRS="$(curve_pairs)"
   TEMP="$(awk '{s+=$1;n++} END{printf "%d", (n? s/n : 0)}' ${SENSORS} 2>/dev/null)"
-  i=1; SPEED=0
-  for th in ${TEMPS}; do
-    if [ "${TEMP}" -gt "${th}" ]; then SPEED="$(echo ${SPEEDS} | cut -d' ' -f${i})"; break; fi
-    i=$((i+1))
+  SPEED=0
+  for pair in ${PAIRS}; do
+    th="${pair%%:*}"
+    [ "${TEMP}" -gt "${th}" ] && { SPEED="${pair#*:}"; break; }
   done
   if [ "${SPEED}" != "${LAST}" ]; then
     echo "${SPEED}" > "${FAN_PWM}" 2>/dev/null

--- a/packages/pocknix-bsp-common/pocknix-fancontrol
+++ b/packages/pocknix-bsp-common/pocknix-fancontrol
@@ -20,6 +20,13 @@ set -u
 MODE_FILE=/var/lib/pocknix/fan-mode
 GAME_MODE_FILE=/run/pocknix/game-mode
 
+# Hysteresis in millidegC (5000 = 5C). On cooldown the fan keeps its current (higher) step
+# until temp falls HYST below the threshold that step was chosen at; on warmup it reacts at
+# the exact threshold. Symmetric behavior, biased toward cooling — safer than the reverse.
+# Wide enough to absorb the idle-vs-active thermal gap near the floor (e.g. Steam menu at
+# ~50-51C otherwise cycles start/stop every tick); tune down if a step holds too long.
+HYST=5000
+
 # Fan PWM (hwmon pwm1) — ROCKNIX 020-fan_control.
 FAN_PWM="$(ls /sys/class/hwmon/hwmon*/pwm1 2>/dev/null | head -1)"
 [ -n "${FAN_PWM}" ] || { echo "pocknix-fancontrol: no hwmon pwm1 fan found, exiting"; exit 0; }
@@ -68,17 +75,31 @@ curve_pairs() {
 trap '[ -e "${FAN_EN}" ] && echo 0 > "${FAN_EN}" 2>/dev/null; exit 0' INT TERM
 
 LAST=""
+LAST_TH=0        # threshold the current step was chosen at; cooldown needs TEMP < TH - HYST.
+LAST_MODE=""     # effective_mode at the current step; a mode change bypasses hysteresis so a
+                 # per-game override ending (e.g. performance -> quiet) doesn't hold a high PWM.
 while :; do
+  MODE="$(effective_mode)"
   PAIRS="$(curve_pairs)"
   TEMP="$(awk '{s+=$1;n++} END{printf "%d", (n? s/n : 0)}' ${SENSORS} 2>/dev/null)"
-  SPEED=0
+  SPEED=0; TH=0
   for pair in ${PAIRS}; do
     th="${pair%%:*}"
-    [ "${TEMP}" -gt "${th}" ] && { SPEED="${pair#*:}"; break; }
+    if [ "${TEMP}" -gt "${th}" ]; then SPEED="${pair#*:}"; TH="${th}"; break; fi
   done
+  # Hysteresis: only honor a cooldown (SPEED < LAST) once temp has fallen HYST below the
+  # threshold LAST was picked at — but only if the mode hasn't changed since. A mode switch
+  # (warm or cool) always applies fresh, so e.g. dropping a per-game performance override
+  # immediately lowers the fan instead of holding the high step until cooldown completes.
+  if [ "${MODE}" = "${LAST_MODE}" ] && [ "${SPEED}" -lt "${LAST}" ] && [ "${TEMP}" -ge $((LAST_TH - HYST)) ]; then
+    SPEED="${LAST}"
+    TH="${LAST_TH}"
+  fi
   if [ "${SPEED}" != "${LAST}" ]; then
     echo "${SPEED}" > "${FAN_PWM}" 2>/dev/null
     LAST="${SPEED}"
+    LAST_TH="${TH}"
   fi
+  LAST_MODE="${MODE}"
   sleep 3
 done

--- a/packages/pocknix-bsp-common/pocknix-fancontrol
+++ b/packages/pocknix-bsp-common/pocknix-fancontrol
@@ -53,7 +53,9 @@ CURVE_PERFORMANCE="80000:255 75000:204 70000:153 65000:119 60000:102 55000:77 50
 # game session (the wrapper execs into Proton), so a dead pid means no override — the pick
 # reverts on any kind of game exit with no cleanup step. "-" = that field not overridden.
 effective_mode() {
-  if read -r pid fan _ < "${GAME_MODE_FILE}" 2>/dev/null; then
+  # 2>/dev/null BEFORE the < so the open failure (no file in idle) is suppressed too —
+  # < file 2>/dev/null doesn't, since the < redirect is evaluated before stderr is muted.
+  if read -r pid fan _ 2>/dev/null < "${GAME_MODE_FILE}"; then
     if [ -n "${pid}" ] && [ "${fan}" != "-" ] && [ -d "/proc/${pid}" ]; then
       printf '%s\n' "${fan}"
       return


### PR DESCRIPTION
## Summary

Reworks the quiet fan profile to be a true early-quiet curve, enforces LF
line endings on overlay scripts so they survive a Windows checkout, and
adds cooldown hysteresis to stop threshold oscillation. moderate/performance
behavior is unchanged.

Three commits, independently reviewable.

## Background

The shipped quiet curve sat idle to 60C, then jumped straight to PWM 51
(~1935 RPM) in a single step — noticeably louder than the vendor Android
profile. Hand-measuring the SM8550 blower (hwmon40) showed the motor
self-starts from PWM=20 (~950 RPM, MINSTART ≈ MINSTOP) and stays barely
audible through PWM=50 (~1935 RPM), with the whistle band beginning around
PWM=80 (~2900 RPM). That gave room for a gentler ramp.

## Commits

### 1. `early-quiet fan curve, refactored to temp:pwm pairs`
- quiet now ramps in from 50C at the silent PWM=50 floor and climbs in
  gentle steps, keeping the whistle band (PWM 80+) above 70C and reaching
  max only in the throttle zone (88C). No more 0→51 jump.
- Engine refactored from two parallel lists (shared `SPEEDS` + per-mode
  `TEMPS`) to per-mode `temp:pwm` pair tables, since quiet now needs its
  own speed steps rather than only shifted thresholds.
- **moderate/performance unchanged** (verified value-by-value against the
  originals).

### 2. `gitattributes: force LF on shell scripts and overlay text`
- Overlay scripts under `/usr/local/bin` are invoked directly by systemd
  units. A CRLF shebang (`/bin/sh\r`) makes the kernel fail to find the
  interpreter and systemd reports status 203/EXEC ("No such file or
  directory") — the exact trap hit while testing this change after a
  Windows checkout + scp.
- Pins `*.sh` and everything under `overlay/` to LF so they stay runnable
  regardless of checkout platform.

### 3. `add cooldown hysteresis to stop threshold oscillation`
- Without hysteresis the fan toggled every ~3s when temp hovered on a
  boundary: idling in the Steam menu at ~50-51C cycled start/stop on the
  quiet floor, and under load it "breathed" between steps (e.g. PWM 80↔90
  around the 74C threshold).
- The engine now tracks the threshold the current step was chosen at
  (`LAST_TH`) and only honors a cooldown once temp has fallen `HYST` below
  it; warmup still applies immediately. Biased toward cooling (overshoot on
  cooldown, no lag on warmup) — the safer direction for a throttling
  handheld.
- `HYST` is a single named constant (default 5000 millidegC / 5C), trivial
  to tune per device.

## Measurement basis (SM8550 blower, hwmon40)

| PWM | RPM   | Audibility                  |
|-----|-------|-----------------------------|
| 20  | ~950  | MINSTART/MINSTOP            |
| 50  | ~1935 | only audible with ear to vent |
| 70  | ~2521 | acceptable whisper          |
| 80  | ~2856 | noticeable whistle begins   |
| 90  | ~3064 | "device is getting hot"     |
| 255 | 6251  | whole room                  |

## Curves (millidegC:pwm, hottest first)
```
quiet: 88:255 82:153 78:102 74:90 70:80 65:70 50:50 0:0 
moderate: 85:255 80:204 75:153 70:119 65:102 60:77 55:51 0:0 
performance: 80:255 75:204 70:153 65:119 60:102 55:77 50:51 0:0
```
## Testing
- `sh -n` passes; committed files verified LF in the index.
- moderate/performance confirmed value-identical to the originals.
- Hysteresis simulated against the quiet curve across five scenarios
  (idle hover, cooldown ramp, warmup ramp, cold start, boundary
  oscillation) — all behave as intended.
- **Live on SM8550 (RP6/Odin2 family):**
  - idle/desktop: silent, no 0→51 step
  - Cult of the Lamb (no compatability checkbox): ~75C avg, 3100 RPM (PWM 90)
  - Cult of the Lamb (Proton 11 CachyOS): 82C avg / 91C peak, 3808 RPM (PWM 102)
  - Steam menu (previously cycled 0↔50 every ~3s): hysteresis eliminated the
    rapid toggling — the fan either holds a steady PWM 50 while temp sits in
    the 50-51C band, or stops cleanly once the device cools below 45C
    (floor − HYST). No more oscillation either way.
  - All cases noticeably quieter than moderate/performance at the same temp