### PR TITLE
input: map Retroid face buttons to Nintendo layout

### DIFF
--- a/devices/sm8250/packages/pocknix-bsp-sm8250/PKGBUILD
+++ b/devices/sm8250/packages/pocknix-bsp-sm8250/PKGBUILD
@@ -16,7 +16,7 @@
 #     (pocknix-bootloader-sm8250), not in a boot-image rebuild file.
 pkgname=pocknix-bsp-sm8250
 pkgver=0.1.0
-pkgrel=10
+pkgrel=14
 pkgdesc="pocknix board support: SM8250 family (RP5, RP Flip 2) — runtime board dispatch, input maps, audio UCM, wake quirks"
 arch=('any')
 url="https://github.com/shuuri-labs/pocknix-os"

--- a/devices/sm8250/packages/pocknix-bsp-sm8250/rp5-gamepad.yaml
+++ b/devices/sm8250/packages/pocknix-bsp-sm8250/rp5-gamepad.yaml
@@ -5,6 +5,8 @@
 # have paddles). BTN_BACK -> QuickAccess (Steam QAM; ROCKNIX had KeyF1 for
 # their UI), BTN_MODE -> Guide. The Flip 2 used to share this map but has no
 # back button — it forks it as rpflip2-gamepad.yaml (Guide+A QAM chord).
+# Face buttons target Steam's A/B/X/Y positions for Retroid's Nintendo
+# legends: BTN_EAST=A, BTN_SOUTH=B, BTN_NORTH=X, BTN_WEST=Y.
 # Schema version number
 version: 2
 
@@ -37,7 +39,7 @@ mapping:
           value_type: button
     target_event:
       gamepad:
-        button: South
+        button: East
 
   - name: West Button
     source_events:
@@ -47,7 +49,7 @@ mapping:
           value_type: button
     target_event:
       gamepad:
-        button: West
+        button: North
 
   - name: North Button
     source_events:
@@ -57,7 +59,7 @@ mapping:
           value_type: button
     target_event:
       gamepad:
-        button: North
+        button: West
 
   - name: East Button
     source_events:
@@ -67,7 +69,7 @@ mapping:
           value_type: button
     target_event:
       gamepad:
-        button: East
+        button: South
 
   - name: Start Button
     source_events:

--- a/devices/sm8250/packages/pocknix-bsp-sm8250/rpflip2-gamepad.yaml
+++ b/devices/sm8250/packages/pocknix-bsp-sm8250/rpflip2-gamepad.yaml
@@ -21,6 +21,8 @@
 #                      chord table), so South must be re-declared as a chord
 #                      and MUST be listed after the Guide+A entry — chord
 #                      candidates match in YAML order.
+# Retroid's Nintendo face-button legends map to Steam's A/B/X/Y positions:
+# BTN_EAST=A, BTN_SOUTH=B, BTN_NORTH=X, BTN_WEST=Y.
 # Semantics verified against the InputPlumber 0.75.2 source
 # (src/input/event/evdev/translator.rs); no upstream config exercises
 # delayed_chord yet, so treat as unproven until the Flip 2 device smoke.
@@ -79,7 +81,7 @@ mapping:
           value_type: button
     target_event:
       gamepad:
-        button: South
+        button: East
 
   - name: West Button
     source_events:
@@ -89,7 +91,7 @@ mapping:
           value_type: button
     target_event:
       gamepad:
-        button: West
+        button: North
 
   - name: North Button
     source_events:
@@ -99,7 +101,7 @@ mapping:
           value_type: button
     target_event:
       gamepad:
-        button: North
+        button: West
 
   - name: East Button
     source_events:
@@ -109,7 +111,7 @@ mapping:
           value_type: button
     target_event:
       gamepad:
-        button: East
+        button: South
 
   - name: Start Button
     source_events:


### PR DESCRIPTION
## What\nMap the Retroid Pocket 5 and Retroid Pocket Flip 2 built-in face buttons to Steam's Nintendo-labelled A/B/X/Y positions.\n\n## How\nUpdate the two Retroid InputPlumber capability maps directly. This keeps the built-in controller as a Steam Deck target while presenting the physical A, B, X, and Y legends at their matching Steam positions.\n\n## Tested\nBuilt pocknix-bsp-sm8250 0.1.0-14 and installed it on a Retroid Pocket 5. Confirmed in Steam that the physical right A, bottom B, top X, and left Y buttons each match their printed labels.\n\n## How to test\n1. Build and install pocknix-bsp-sm8250 on an RP5 or Flip 2.\n2. Restart InputPlumber or reboot.\n3. In Steam, confirm the physical right A button acts as A, bottom B acts as B, top X acts as X, and left Y acts as Y.\n4. Confirm the Steam and Quick Access buttons still work.\n\n## Checklist\n- [x] Retroid-specific change only\n- [x] No new runtime service or user setting\n- [x] Tested on RP5 hardware\n- [ ] Tested on Flip 2 hardware\n\nHardware available: Retroid Pocket 5 only. Flip 2 remains untested.