### PR TITLE
docs: replace broken Discord invite link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: pocknix Discord
-    url: https://discord.gg/vcDtuNfmC
+    url: https://discord.gg/mSSNKQg9m
     about: Questions, ideas, and quick help. Confirmed bugs end up here as issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ hardware, so the most valuable thing a PR can bring is **evidence it works on a 
 and **instructions that let me reproduce that on mine**.
 
 Questions, ideas, or "is this worth doing?" chats: the
-[pocknix Discord](https://discord.gg/vcDtuNfmC) or a GitHub issue. For anything large
+[pocknix Discord](https://discord.gg/mSSNKQg9m) or a GitHub issue. For anything large
 (a new device family, a new session, a kernel bump, a new packaging approach), open an issue
 first so we can agree the shape before you spend the time.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pocknix-os
 
-> Questions, bug reports, or just want to hang out? Join the [pocknix Discord](https://discord.gg/vcDtuNfmC)!
+> Questions, bug reports, or just want to hang out? Join the [pocknix Discord](https://discord.gg/mSSNKQg9m)!
 
 **pocknix-os is an Arch Linux ARM (ALARM) based distro for Retroid and AYN Snapdragon handhelds.** Using the Steam ARM client, it turns these handhelds into devices that feel like a Steam Deck - power on, land in SteamOS gaming mode, pick a game, and play - but it does so on a fully mutable and performance-tuned Arch Linux base, so it's closer to something like CachyOS Handheld Edition than to real SteamOS, Bazzite, or armada.
 


### PR DESCRIPTION
## What

The Discord invite used in the README, CONTRIBUTING.md, and the issue template config (`https://discord.gg/vcDtuNfmC`) is broken — it currently returns a 404 / "invite invalid" from Discord.

This PR replaces it with `https://discord.gg/mSSNKQg9m`, an invite I found shared on Reddit. I verified it resolves to a server named **pocknix** (~324 members), so it looks like the right one.

## Note for the maintainer

- As I'm not the server owner, please double-check this is the official pocknix server. If you'd rather use a different invite, feel free to suggest one and I'll update the PR (or just edit it directly).
- Heads up: this invite appears to be **temporary** (Discord reports it expiring on 2026-09-06). It would be better to swap in a permanent invite generated by a server admin before merging.