### PR TITLE
emulation: point the arcade systems at cores we actually ship

### DIFF
--- a/packages/shared/pocknix-emulation/PKGBUILD
+++ b/packages/shared/pocknix-emulation/PKGBUILD
@@ -2,7 +2,7 @@
 # configs, shipped as an arch=any data/scripts package.
 pkgname=pocknix-emulation
 pkgver=0.1.0
-pkgrel=13
+pkgrel=14
 pkgdesc="ES-DE + preconfigured emulators for the RP6: drop ROMs into ~/Emulation and play; star -> Steam"
 arch=('any')
 url="https://github.com/shuuri-labs/pocknix-os"

--- a/packages/shared/pocknix-emulation/es_systems.xml
+++ b/packages/shared/pocknix-emulation/es_systems.xml
@@ -5,7 +5,9 @@
   FULL definition, not a delta. Each one exists because the bundled launch commands name cores or
   standalones we do not ship: ps2 offers only the LRPS2 core, psx names a DuckStation standalone
   that has no arm64 build (ours is the libretro core), gc/wii default to the RetroArch dolphin
-  core. All commands go through the /usr/lib/pocknix/es-* wrappers for the big-core pin.
+  core; cps1/cps2/cps3/arcade/mame all default to mame_libretro, which we do not ship.
+  The console entries go through the /usr/lib/pocknix/es-* wrappers for the big-core pin;
+  the arcade ones are libretro cores, so they use RetroArch directly.
 -->
 <systemList>
     <system>
@@ -108,5 +110,60 @@
         <command label="Shortcut or script">%ENABLESHORTCUTS% %EMULATOR_OS-SHELL% %ROM%</command>
         <platform>psvita</platform>
         <theme>psvita</theme>
+    </system>
+    <system>
+        <name>cps1</name>
+        <fullname>Capcom Play System I</fullname>
+        <path>%ROMPATH%/cps1</path>
+        <extension>.7z .7Z .zip .ZIP</extension>
+        <command label="FinalBurn Neo">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/fbneo_libretro.so %ROM%</command>
+        <command label="MAME 2003-Plus">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/mame2003_plus_libretro.so %ROM%</command>
+        <command label="Shortcut or script">%ENABLESHORTCUTS% %EMULATOR_OS-SHELL% %ROM%</command>
+        <platform>arcade</platform>
+        <theme>cps1</theme>
+    </system>
+    <system>
+        <name>cps2</name>
+        <fullname>Capcom Play System II</fullname>
+        <path>%ROMPATH%/cps2</path>
+        <extension>.7z .7Z .zip .ZIP</extension>
+        <command label="FinalBurn Neo">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/fbneo_libretro.so %ROM%</command>
+        <command label="MAME 2003-Plus">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/mame2003_plus_libretro.so %ROM%</command>
+        <command label="Shortcut or script">%ENABLESHORTCUTS% %EMULATOR_OS-SHELL% %ROM%</command>
+        <platform>arcade</platform>
+        <theme>cps2</theme>
+    </system>
+    <system>
+        <name>cps3</name>
+        <fullname>Capcom Play System III</fullname>
+        <path>%ROMPATH%/cps3</path>
+        <extension>.7z .7Z .zip .ZIP</extension>
+        <command label="FinalBurn Neo">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/fbneo_libretro.so %ROM%</command>
+        <command label="MAME 2003-Plus">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/mame2003_plus_libretro.so %ROM%</command>
+        <command label="Shortcut or script">%ENABLESHORTCUTS% %EMULATOR_OS-SHELL% %ROM%</command>
+        <platform>arcade</platform>
+        <theme>cps3</theme>
+    </system>
+    <system>
+        <name>arcade</name>
+        <fullname>Arcade</fullname>
+        <path>%ROMPATH%/arcade</path>
+        <extension>.cmd .CMD .desktop .gam .GAM .neo .NEO .sh .7z .7Z .zip .ZIP</extension>
+        <command label="FinalBurn Neo">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/fbneo_libretro.so %ROM%</command>
+        <command label="MAME 2003-Plus">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/mame2003_plus_libretro.so %ROM%</command>
+        <command label="Shortcut or script">%ENABLESHORTCUTS% %EMULATOR_OS-SHELL% %ROM%</command>
+        <platform>arcade</platform>
+        <theme>arcade</theme>
+    </system>
+    <system>
+        <name>mame</name>
+        <fullname>Multiple Arcade Machine Emulator</fullname>
+        <path>%ROMPATH%/mame</path>
+        <extension>.cmd .CMD .desktop .gam .GAM .neo .NEO .sh .7z .7Z .zip .ZIP</extension>
+        <command label="FinalBurn Neo">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/fbneo_libretro.so %ROM%</command>
+        <command label="MAME 2003-Plus">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/mame2003_plus_libretro.so %ROM%</command>
+        <command label="Shortcut or script">%ENABLESHORTCUTS% %EMULATOR_OS-SHELL% %ROM%</command>
+        <platform>arcade</platform>
+        <theme>mame</theme>
     </system>
 </systemList>


### PR DESCRIPTION
## What

`cps1`, `cps2`, `cps3`, `arcade` and `mame` all fall through to ES-DE's bundled definitions, which default to `mame_libretro.so`. We don't ship that core, so launching anything from those systems fails with "could not find mame_libretro.so". I hit it on cps1, which is the only one of the five I have ROMs in.

```
cps1        mame_libretro.so     MISSING   roms=137
cps2        mame_libretro.so     MISSING   roms=0
cps3        mame_libretro.so     MISSING   roms=0
arcade      mame_libretro.so     MISSING   roms=0
mame        mame_libretro.so     MISSING   roms=0
neogeo      fbneo_libretro.so    OK        roms=101
```

`neogeo` is already fine because ES-DE's bundled default for it happens to be a core we ship.

## How

Full custom definitions for the five, defaulting to FinalBurn Neo, with MAME 2003-Plus as the second command so switching is one selection in ES-DE's alternative-emulator menu. Both cores are in `libretro-cores-pocknix`.

Defaulted to fbneo for consistency with how `neogeo` already resolves. On coverage the two are close — of my 137 cps1 sets, fbneo recognises 102 and mame2003_plus 104, with 82 in both and 13 in neither. So neither core is a complete answer and having the alternative one button away matters more than which is first.

These use `%EMULATOR_RETROARCH%` rather than an `es-*` wrapper, since they're libretro cores. I extended the header comment to note that, as it previously said all commands go through the wrappers.

## Tested

- **Device:** Retroid Pocket 6, sm8550, internal install
- Confirmed the five defaults resolve to a missing core, and that `fbneo_libretro.so` and `mame2003_plus_libretro.so` are both present
- Checked all 137 cps1 set names against both cores' romset databases
- `xml.etree` parses the file; all 15 systems present

**Not tested:** the built package, and launching a game from the new entries. No Arch ARM build host here, and the seeded `es_systems.xml` only refreshes on first login, so I have not watched this arrive through `-Syu` and take effect. Worth someone confirming a cps1 game actually boots before merge — my romset check is a name lookup in the core binary, not proof the ROM runs.

## Checklist

- [x] `pkgrel` bumped (`pocknix-emulation` 13 to 14)
- [ ] Survives a reboot / cold boot — not power-cycle verified
- [ ] Reaches existing installs through `-Syu` — not verified, see above
- [x] Degrades quietly — empty systems stay hidden; the alternative core is one menu selection
- [x] CI lint green, commit follows `area: summary`
- [x] AI assistance disclosed

## AI assistance

Written with an AI assistant, per CONTRIBUTING. The coverage numbers come from checking the sets on my own device, not from documentation.
